### PR TITLE
Fix Deprecation Error "Round"

### DIFF
--- a/src/templates/_verify.twig
+++ b/src/templates/_verify.twig
@@ -9,7 +9,7 @@
     <form id="verify-form" class="verify-form-centered centeralign" action="{{ actionUrl('two-factor-authentication/verify/login-process') }}" method="post" accept-charset="UTF-8" {% if hasLogo -%}
             {%- set logo = craft.rebrand.logo -%}
             {%- set padding = logo.height + 30 -%}
-            class="has-logo" style="background-image: url('{{ logo.url }}'); background-size: {{ logo.width }}px {{ logo.height }}px; padding-top: {{ padding }}px; margin-top: -{{ round((353+padding)/2) }}px"
+            class="has-logo" style="background-image: url('{{ logo.url }}'); background-size: {{ logo.width }}px {{ logo.height }}px; padding-top: {{ padding }}px; margin-top: -{{ (353+padding)/2|round }}px"
         {%- endif %}>
 
         {{ csrfInput() }}


### PR DESCRIPTION
Currently logging in with 2fa creates a deprecation error, as round() is deprecated in Craft 3 and will be removed entirely in Craft 4:
https://docs.craftcms.com/v3/changes-in-craft-3.html#template-functions

This switches to the Twig |round filter to avoid the error.