### PR TITLE
Defer validate request until after Craft is fully loaded.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,6 +18,7 @@ use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterElementTableAttributesEvent;
 use craft\events\SetElementTableAttributeHtmlEvent;
+use craft\web\Application;
 use craft\web\UrlManager;
 use craft\web\twig\variables\CraftVariable;
 use yii\base\Event;
@@ -62,7 +63,7 @@ class Plugin extends CraftPlugin
             'verify' => VerifyService::class,
         ]);
 
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function () {
+        Event::on(Application::class, Application::EVENT_INIT, function () {
             $this->request->validateRequest();
         });
 


### PR DESCRIPTION
Defer validate request until after Craft is fully loaded.

Problem that occurred: after login the 2fa screen is presented. Go back to the previous page and you are logged in!
Even though EVENT_AFTER_LOAD_PLUGINS already defers the user check, Craft::$app->getUser()->getIdentity() is null.