### PR TITLE
Fix how TOTP is created

### DIFF
--- a/src/services/Verify.php
+++ b/src/services/Verify.php
@@ -103,7 +103,7 @@ class Verify extends Component
     public function disableUser(User $user)
     {
         // Update the user record
-        $totp = new TOTP($user->email);
+        $totp = TOTP::create($user->email);
         $userRecord = $this->getUserRecord($user);
         // Remove verified state
         $userRecord->dateVerified = null;
@@ -169,7 +169,7 @@ class Verify extends Component
         ]);
 
         if (!isset($userRecord)) {
-            $totp = new TOTP($user->email);
+            $totp = TOTP::create($user->email);
             $userRecord = new UserRecord();
             $userRecord->userId = $user->id;
             $userRecord->secret = $totp->getSecret();


### PR DESCRIPTION
The TOTP constructor is protected as of version 9, so a PHP error is thrown when it is called from the plugin.
https://github.com/Spomky-Labs/otphp/blob/bfd24fe5b38b5d17cfa774224b000750ee51643c/src/TOTP.php#L21-L26

This PR fixes how TOTP instances are created.