### PR TITLE
WIP: Fix for conflicts with new config option asyncCsrfInputs=true since craftcms 4.9

### DIFF
--- a/src/templates/_settings/base.twig
+++ b/src/templates/_settings/base.twig
@@ -22,7 +22,7 @@
     <p>{{ 'To disable two-factor authentication, click the button below.'|t('two-factor-authentication') }}</p>
 
     <form id="turnoff-form" action="{{ actionUrl('two-factor-authentication/settings/turn-off') }}" method="post" accept-charset="UTF-8">
-        {{ csrfInput() }}
+        {{ csrfInput({async:false}) }}
 
         <input id="submit" class="btn submit icon insecure" type="submit" value="{{- "I don't want two-factor authentication"|t('two-factor-authentication') -}}">
     </form>
@@ -77,7 +77,7 @@
     } %}
 
     <form {{ attr(formAttributes) }}>
-        {{ csrfInput() }}
+        {{ csrfInput({async:false}) }}
 
         {{ forms.textField({
             id: "authenticationCode",

--- a/src/templates/_user/status.twig
+++ b/src/templates/_user/status.twig
@@ -10,7 +10,7 @@
             {% if enabled %}
                 <form id="turnoff-form" method="post" accept-charset="UTF-8">
                     <input type="hidden" name="action" value="two-factor-authentication/users/turn-off">
-                    {{ csrfInput() }}
+                    {{ csrfInput({async:false}) }}
                     <input type="hidden" name="userId" value="{{ user.id }}">
 
                     <button class="btn submit" type="submit" data-icon="insecure">

--- a/src/templates/_verify.twig
+++ b/src/templates/_verify.twig
@@ -36,7 +36,7 @@
             </h1>
 
             <form {{ attr(formAttributes) }}>
-                {{ csrfInput() }}
+                {{ csrfInput({async:false}) }}
 
                 <h2>{{ 'Two-Factor Authentication'|t('two-factor-authentication') }}</h2>
                 <p>{{ "Enter the authentication code from your phone."|t('two-factor-authentication') }}</p>


### PR DESCRIPTION
Hey! 
The new config option named `asyncCsrfInputs` that is out since CraftCMS 4.9 conflicts with this plugin that results in a Crsf Token input that couldn't be verified.

**What happens?:**
_The crsf-token could not be retrieved and it resolves in a undefined hidden input:_
![image](https://github.com/born05/craft-twofactorauthentication/assets/90032/871e38f6-c93d-460a-b8e6-082245932b5d)

_Crsf Input that should be filled is undefined:_
![image](https://github.com/born05/craft-twofactorauthentication/assets/90032/0128637b-78fb-4309-ad0a-e6816dff4d8d)

With this fix the hidden Csrf input is properly set:
![image](https://github.com/born05/craft-twofactorauthentication/assets/90032/45ac96a5-0e63-4edf-978a-d1d5fa7730a8)

Edit: Looks like this fix still work in progress as the actionLoginProcess() is now returning a `Unable to verify your data submission.`

Edit2: It now returns an error at validateRequest, I'm sorry I don't have time to look into it any deeper right now.