### PR TITLE
Fix for conflicts with new config option asyncCsrfInputs=true

### DIFF
--- a/src/services/Request.php
+++ b/src/services/Request.php
@@ -114,8 +114,10 @@ class Request extends Component
 
         $pathInfo = $request->getPathInfo();
 
+        $backEndPathAllow = array_merge(['actions/users/session-info'], $settings->backEndPathAllow);
+
         $isAllowed = false;
-        foreach ($settings->backEndPathAllow as $path) {
+        foreach ($backEndPathAllow as $path) {
             if ($this->isRegex("/$path/i")) {
                 if (preg_match("/$path/i", $pathInfo)) {
                     $isAllowed = true;


### PR DESCRIPTION
This fixes a bug for Craft 4.9+ where `asyncCsrfInputs=true` in the general config.
The token verification fails and the login doesn't work.

If this doesn't get merged the workaround for this is setting the backendPathAllow to 'actions/users/session-info' like this:
```
'backEndPathAllow' => [
	'actions/users/session-info'
]
```

